### PR TITLE
Fix/test handling of getUnit divisor edge-cases

### DIFF
--- a/byteformatter.go
+++ b/byteformatter.go
@@ -129,7 +129,7 @@ func getUnit(ss SizeSystem, size int64) (divider int64, name, short string) {
 		}
 		return div / ss.MultiPlier, ss.Names[i-1], ss.Shorts[i-1]
 	}
-	return div, ss.Names[len(ss.Names)-1], ss.Shorts[len(ss.Shorts)-1]
+	return div / ss.MultiPlier, ss.Names[len(ss.Names)-1], ss.Shorts[len(ss.Shorts)-1]
 }
 
 // FormatSize formats a number of bytes using the given unit standard system.

--- a/byteformatter_test.go
+++ b/byteformatter_test.go
@@ -1,0 +1,91 @@
+package progressio
+
+import "testing"
+
+func Test_getUnit(t *testing.T) {
+
+	// This is to more visually exercise the top edge case of the getUnit routine
+	var distanceSize = SizeSystem{
+		Name:       "distance",
+		MultiPlier: 1000,
+		Names:      []string{"metre", "kilometre"},
+		Shorts:     []string{"m", "km"},
+	}
+
+	type args struct {
+		ss   SizeSystem
+		size int64
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantDivider int64
+		wantName    string
+		wantShort   string
+	}{
+		{
+			name:        "IEC 0",
+			args:        args{ss: IEC, size: 0},
+			wantDivider: Byte, wantName: "byte", wantShort: "B",
+		},
+		{
+			name:        "IEC 1234",
+			args:        args{ss: IEC, size: 1234},
+			wantDivider: KibiByte, wantName: "kibibyte", wantShort: "KiB",
+		},
+		{
+			name:        "IEC 1234567",
+			args:        args{ss: IEC, size: 1234567},
+			wantDivider: MebiByte, wantName: "mebibyte", wantShort: "MiB",
+		},
+		{
+			name:        "JEDEC 1234",
+			args:        args{ss: JEDEC, size: 1234},
+			wantDivider: KibiByte, wantName: "kilobyte", wantShort: "KB",
+		},
+		{
+			name:        "JEDEC 1234567",
+			args:        args{ss: JEDEC, size: 1234567},
+			wantDivider: MebiByte, wantName: "megabyte", wantShort: "MB",
+		},
+		{ // Uses top element
+			name:        "IEC top edge case",
+			args:        args{ss: IEC, size: PebiByte},
+			wantDivider: PebiByte, wantName: "pebibyte", wantShort: "PiB",
+		},
+		{ // Exceeds top element
+			name:        "IEC exceeds top edge case",
+			args:        args{ss: IEC, size: IECMultiplier * PebiByte},
+			wantDivider: PebiByte, wantName: "pebibyte", wantShort: "PiB",
+		},
+		{
+			name:        "Distance 1",
+			args:        args{ss: distanceSize, size: 1},
+			wantDivider: 1, wantName: "metre", wantShort: "m",
+		},
+		{
+			name:        "Distance 1000",
+			args:        args{ss: distanceSize, size: 1000},
+			wantDivider: 1000, wantName: "kilometre", wantShort: "km",
+		},
+		{ // There is no mega-metre defined, so should return highest mapped divisor - 1000 for km
+			name:        "Distance 1000000",
+			args:        args{ss: distanceSize, size: 1000000},
+			wantDivider: 1000, wantName: "kilometre", wantShort: "km",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotDivider, gotName, gotShort := getUnit(tt.args.ss, tt.args.size)
+			if gotDivider != tt.wantDivider {
+				t.Errorf("getUnit() gotDivider = %v, want %v", gotDivider, tt.wantDivider)
+			}
+			if gotName != tt.wantName {
+				t.Errorf("getUnit() gotName = %v, want %v", gotName, tt.wantName)
+			}
+			if gotShort != tt.wantShort {
+				t.Errorf("getUnit() gotShort = %v, want %v", gotShort, tt.wantShort)
+			}
+		})
+	}
+}

--- a/progress_test.go
+++ b/progress_test.go
@@ -90,7 +90,7 @@ func TestIOProgress(t *testing.T) {
 	iop.startTime = time.Now().Add(time.Second * -10)
 	go iop.updateProgress(0)
 	p := <-iop.ch
-	t.Logf("P: %p\n", p)
+	t.Logf("P: %p\n", &p)
 	t.Logf("P: %s\n", p.String())
 	//t.Fail()
 }


### PR DESCRIPTION
I was trying to create a reduced sized formatter (really just kB) and ran into issues with the final output.

On inspection it turns out that the problem was around how `getUnit` behaves when it meets or exceeds the top mapped element for the size system.
